### PR TITLE
feat(ze_collective): Block AC detection for Hackerman Item

### DIFF
--- a/addons/sourcemod/scripting/FixMapsFiles.sp
+++ b/addons/sourcemod/scripting/FixMapsFiles.sp
@@ -4,17 +4,29 @@
 #include <sourcemod>
 #include <sdktools>
 
+// Uncomment to enable lilac fix for ze_collective_css
+//#define ENABLE_COLLECTIVE_MODULE
+
+#if defined ENABLE_COLLECTIVE_MODULE
+bool g_bCollective = false;
+#include "modules/ze_collective"
+#endif
+
 public Plugin myinfo = 
 {
 	name = "Maps files fixer",
 	author = ".Rushaway",
 	description = "Downloads fixed files for multiples map",
-	version = "1.1.0",
+	version = "1.2.0",
 	url = ""
 };
 
 public void OnMapStart()
 {
+#if defined ENABLE_COLLECTIVE_MODULE
+	g_bCollective = false;
+#endif
+
 	char sCurrentMap[256];
 	GetCurrentMap(sCurrentMap, sizeof(sCurrentMap));
 	if (strcmp(sCurrentMap, "ze_paranoid_rezurrection_v11_9", false) == 0)
@@ -32,6 +44,12 @@ public void OnMapStart()
 	{
 		ApplyGargantuaFix();
 	}
+	#if defined ENABLE_COLLECTIVE_MODULE
+	else if (strncmp(sCurrentMap, "ze_collective_css", 17, false) == 0)
+	{
+		g_bCollective = true;
+	}
+#endif
 }
 
 stock void ApplyParanoidFix()

--- a/addons/sourcemod/scripting/modules/ze_collective.inc
+++ b/addons/sourcemod/scripting/modules/ze_collective.inc
@@ -1,0 +1,25 @@
+#tryinclude <lilac>
+
+#if defined _lilac_included
+// Hackerman Item on ze_collective_css can trigger detection, block the detection for this item only
+public bool lilac_allow_cheat_detection(int client, int cheat)
+{
+	if (!g_bCollective)
+		return false;
+
+	if (cheat == CHEAT_AIMBOT)
+	{
+		int weapon = GetPlayerWeaponSlot(client, 1);
+		if (weapon == -1)
+			return false;
+
+		if (GetEntProp(weapon, Prop_Data, "m_iHammerID") == 11111017)
+		{
+			LogAction(-1, -1, "Blocked cheat detection (Aimbot) for client %L on ze_collective_css for Hackerman Item", client);
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif


### PR DESCRIPTION
- This fix is disabled by default, for now only lilac detect this item as cheat and their no plan to enabled it on master.